### PR TITLE
Fix parity bits

### DIFF
--- a/esp_uart.h
+++ b/esp_uart.h
@@ -41,9 +41,9 @@ extern "C" {
 #define UART_BITS_EIGHT         0x0C
 #define UART_BITS_MASK          0x0C
 
-#define UART_PARITY_EVEN        0x00
-#define UART_PARITY_ODD         0x01
 #define UART_PARITY_NONE        0x00
+#define UART_PARITY_EVEN        0x02
+#define UART_PARITY_ODD         0x03
 #define UART_PARITY_MASK        0x03
 
 #define UART_FLAGS_8N1 (UART_BITS_EIGHT | UART_PARITY_NONE | UART_STOP_BITS_ONE)

--- a/esp_uart.h
+++ b/esp_uart.h
@@ -43,7 +43,7 @@ extern "C" {
 
 #define UART_PARITY_EVEN        0x00
 #define UART_PARITY_ODD         0x01
-#define UART_PARITY_NONE        0x02
+#define UART_PARITY_NONE        0x00
 #define UART_PARITY_MASK        0x03
 
 #define UART_FLAGS_8N1 (UART_BITS_EIGHT | UART_PARITY_NONE | UART_STOP_BITS_ONE)


### PR DESCRIPTION
I had problems receiving data in a rapid succession. After comparing the initialization code I discovered a discrepancy within the set bits for the parity flags. All settings (none, even, odd) now produce correct results.